### PR TITLE
LUT-32551 : Put assignment type 'transfer' as default for task unit assignment configuration

### DIFF
--- a/src/java/fr/paris/lutece/plugins/workflow/modules/unittree/web/task/AbstractUnitAssignmentTaskComponent.java
+++ b/src/java/fr/paris/lutece/plugins/workflow/modules/unittree/web/task/AbstractUnitAssignmentTaskComponent.java
@@ -76,6 +76,7 @@ public abstract class AbstractUnitAssignmentTaskComponent extends AbstractUnittr
     // Other contants
     private static final String BUTTON_ADD_UNIT_SELECTION = "addUnitSelection";
     private static final String BUTTON_REMOVE_UNIT_SELECTION = "removeUnitSelection";
+    private static final String DEFAULT_ASSIGNMENT_TYPE = "transfer";
 
     /**
      * {@inheritDoc}
@@ -173,7 +174,13 @@ public abstract class AbstractUnitAssignmentTaskComponent extends AbstractUnittr
         {
             config = new TaskUnitAssignmentConfig( );
             config.setIdTask( task.getId( ) );
+            config.setAssignmentType( DEFAULT_ASSIGNMENT_TYPE );
             getTaskConfigService( ).create( config );
+        }
+        else if ( StringUtils.isBlank( config.getAssignmentType( ) ) )
+        {
+            config.setAssignmentType( DEFAULT_ASSIGNMENT_TYPE );
+            getTaskConfigService( ).update( config );
         }
 
         return config;


### PR DESCRIPTION
Add Transfer as default value in assignment type : 

<img width="1616" height="959" alt="image" src="https://github.com/user-attachments/assets/c3969c8f-e64d-4326-a059-0818015baef1" />

So, the value can't be null and a value is always saved. 

If a value is already set, nothing change. If the value is null, the default value is **transfer**
Here the code for this part : 

<img width="701" height="164" alt="image" src="https://github.com/user-attachments/assets/b238ec6e-42d5-4696-8ea2-00d9f048dbcf" />


