### PR TITLE
LUT-32551-v8 : Put assignment type 'transfer' as default for task unit assignment configuration

### DIFF
--- a/src/java/fr/paris/lutece/plugins/workflow/modules/unittree/web/task/AbstractUnitAssignmentTaskComponent.java
+++ b/src/java/fr/paris/lutece/plugins/workflow/modules/unittree/web/task/AbstractUnitAssignmentTaskComponent.java
@@ -76,6 +76,7 @@ public abstract class AbstractUnitAssignmentTaskComponent extends AbstractUnittr
     // Other contants
     private static final String BUTTON_ADD_UNIT_SELECTION = "addUnitSelection";
     private static final String BUTTON_REMOVE_UNIT_SELECTION = "removeUnitSelection";
+    private static final String DEFAULT_ASSIGNMENT_TYPE = "transfer";
 
     /**
      * {@inheritDoc}
@@ -173,7 +174,13 @@ public abstract class AbstractUnitAssignmentTaskComponent extends AbstractUnittr
         {
             config = new TaskUnitAssignmentConfig( );
             config.setIdTask( task.getId( ) );
+            config.setAssignmentType( DEFAULT_ASSIGNMENT_TYPE );
             getTaskConfigService( ).create( config );
+        }
+        else if ( StringUtils.isBlank( config.getAssignmentType( ) ) )
+        {
+            config.setAssignmentType( DEFAULT_ASSIGNMENT_TYPE );
+            getTaskConfigService( ).update( config );
         }
 
         return config;


### PR DESCRIPTION
same as PR v7 : https://github.com/lutece-platform/lutece-wf-module-workflow-unittree/pull/27